### PR TITLE
Fix a bug that dont allow user upload same file

### DIFF
--- a/ReactS3Uploader.js
+++ b/ReactS3Uploader.js
@@ -87,7 +87,8 @@ var ReactS3Uploader = createReactClass({
             scrubFilename: this.props.scrubFilename,
             s3path: this.props.s3path,
             usePostForm: this.props.usePostForm,
-            acl: this.props.acl
+            acl: this.props.acl,
+            clear: this.clear
         });
     },
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-s3-uploader",
-  "version": "4.9.0",
+  "version": "4.9.1",
   "description": "React component that renders a file input and automatically uploads to an S3 bucket",
   "main": "index.js",
   "scripts": {

--- a/s3upload.js
+++ b/s3upload.js
@@ -62,6 +62,7 @@ S3Upload.prototype.handleFileSelect = function(files) {
             }.bind(this)
         );
     }
+    this.clear();
 };
 
 S3Upload.prototype.createCORSRequest = function(method, url, opts) {
@@ -191,13 +192,13 @@ S3Upload.prototype.uploadToS3 = function(file, signResult) {
         }
 
     }
-    
+
     if (!xhr) {
         return this.onError('CORS not supported', file);
     }
-    
+
     formData.append('file', file);
-    
+
     if (this.uploadRequestHeaders) {
         const uploadRequestHeaders = this.uploadRequestHeaders;
         Object.keys(uploadRequestHeaders).forEach(key => {


### PR DESCRIPTION
When user uploads one file and for some reason (deleted last one) try upload again the same file the browser doesn't trigger the events to start the upload process.

This fix clean the input file value after perform upload