### PR TITLE
[TFMFE-2980] fix safari trigger click

### DIFF
--- a/ReactS3Uploader.js
+++ b/ReactS3Uploader.js
@@ -109,7 +109,8 @@ var ReactS3Uploader = createReactClass({
         // `inputRef` by `ReactS3Uploader.propTypes`
         var additional = {
             type: 'file',
-            ref: this.props.inputRef
+            ref: this.props.inputRef,
+            style: {cursor: 'pointer'},
         };
 
         if (this.props.autoUpload) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-s3-uploader",
-  "version": "4.9.0",
+  "version": "4.9.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-s3-uploader",
-  "version": "4.9.1",
+  "version": "4.9.2",
   "description": "React component that renders a file input and automatically uploads to an S3 bucket",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
https://jira.lafourchette.io/browse/TFMFE-2980

Safari doesn't allow javascript trigger 'click' event in elements that don't match some conditions that identify that this element is a triggered element.

- could be add onClick listener.
- could be add cursor: pointer css rule.


