### PR TITLE
chore: activate stale PRs workflow for repo

### DIFF
--- a/.github/workflows/stale-prs.yml
+++ b/.github/workflows/stale-prs.yml
@@ -1,0 +1,11 @@
+name: Close stale PRs
+
+on:
+  schedule:
+    # Run daily at 10:00 AM UTC
+    - cron: '0 10 * * *'
+  workflow_dispatch:
+
+jobs:
+  stale-prs:
+    uses: lafourchette/github-actions/.github/workflows/stale-prs.yml@v1


### PR DESCRIPTION
PR automatically patch new workflow for stale PRs
This workflow will first be deployed to manage dependency update PRs:
- Target PRs with labels: dependencies, auto-dependencies-upgrade
- Mark stale after 15 days of inactivity
- Close after 5 additional days